### PR TITLE
set up  joining, leaving, and conditional rendering functionality in Mission page

### DIFF
--- a/src/pages/Missions.js
+++ b/src/pages/Missions.js
@@ -1,29 +1,33 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { fetchMissions } from '../redux/missions/missionsSlice';
+import { fetchMissions, joinMission, leaveMission } from '../redux/missions/missionsSlice';
 
 const StyledMission = styled.div`
   width: 80vw;
   margin: 20px auto;
+
   table {
     border-collapse: collapse;
+
     th,
     td {
       border: 1px solid lightgray;
       padding: 5px;
     }
+
     .missionButton {
       background-color: white;
       border: 1px solid gray;
       color: gray;
     }
+
     .status {
-      background-color: gray;
       text-align: center;
       color: white;
       border-radius: 5px;
     }
+
     .rows:nth-child(odd) {
       background-color: #f2f2f2;
     }
@@ -33,13 +37,25 @@ const StyledMission = styled.div`
 function Missions() {
   const dispatch = useDispatch();
 
-  const missionsData = useSelector((state) => state.missions.rockets);
-  const missionsStatus = useSelector((state) => state.missions.status);
-  const missionsError = useSelector((state) => state.missions.error);
+  const {
+    missions: missionsData,
+    status: missionsStatus,
+    error: missionsError,
+  } = useSelector((store) => store.missions);
 
   useEffect(() => {
-    dispatch(fetchMissions());
-  }, [dispatch]);
+    if (missionsData.length === 0) {
+      dispatch(fetchMissions());
+    }
+  }, [dispatch, missionsData]);
+
+  const handleJoinMission = (missionId) => {
+    dispatch(joinMission(missionId));
+  };
+
+  const handleLeaveMission = (missionId) => {
+    dispatch(leaveMission(missionId));
+  };
 
   if (missionsStatus === 'loading') {
     return (
@@ -52,6 +68,7 @@ function Missions() {
       <h1 style={{ marginLeft: '40px' }}>{missionsError}</h1>
     );
   }
+
   return (
     <StyledMission>
       <table>
@@ -72,8 +89,31 @@ function Missions() {
             <tr className="rows" key={item.mission_id}>
               <td className="name">{item.mission_name}</td>
               <td className="description">{item.description}</td>
-              <td className="statusColumn"><div className="status">Not A Member</div></td>
-              <td className="buttonColumn"><button type="button" className="missionButton">Join Mission</button></td>
+              <td className="statusColumn">
+                <div style={item.joined ? { backgroundColor: 'green' } : { backgroundColor: 'grey' }} className="status">
+                  {item.joined ? 'Active Member' : 'Not A Member'}
+                </div>
+              </td>
+              <td className="buttonColumn">
+                {item.joined ? (
+                  <button
+                    type="button"
+                    className="missionButton"
+                    style={{ border: '1px solid red', color: 'red' }}
+                    onClick={() => handleLeaveMission(item.mission_id)}
+                  >
+                    Leave Mission
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="missionButton"
+                    onClick={() => handleJoinMission(item.mission_id)}
+                  >
+                    Join Mission
+                  </button>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/src/pages/Missions.js
+++ b/src/pages/Missions.js
@@ -15,11 +15,11 @@ const StyledMission = styled.div`
     }
     .missionButton {
       background-color: white;
-      border: 1px solid red;
-      color: red;
+      border: 1px solid gray;
+      color: gray;
     }
     .status {
-      background-color: green;
+      background-color: gray;
       text-align: center;
       color: white;
       border-radius: 5px;
@@ -72,8 +72,8 @@ function Missions() {
             <tr className="rows" key={item.mission_id}>
               <td className="name">{item.mission_name}</td>
               <td className="description">{item.description}</td>
-              <td className="statusColumn"><div className="status">Active Member</div></td>
-              <td className="buttonColumn"><button type="button" className="missionButton">Leave Mission</button></td>
+              <td className="statusColumn"><div className="status">Not A Member</div></td>
+              <td className="buttonColumn"><button type="button" className="missionButton">Join Mission</button></td>
             </tr>
           ))}
         </tbody>

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,61 +1,62 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-
+import { createSlice, createAsyncThunk, isRejectedWithValue } from '@reduxjs/toolkit';
 import axios from 'axios';
 
 const initialState = {
-
-  rockets: [],
-
+  missions: [],
   status: 'idle',
-
   error: null,
-
 };
 
 const URL = 'https://api.spacexdata.com/v3/missions';
 
-export const fetchMissions = createAsyncThunk(
-
-  'missions/fetchMissions',
-
-  async () => {
+export const fetchMissions = createAsyncThunk('missions/fetchMissions', async () => {
+  try {
     const response = await axios.get(URL);
-
     return response.data;
-  },
-
-);
+  } catch (error) {
+    return isRejectedWithValue(error.response.data);
+  }
+});
 
 export const missionsSlice = createSlice({
-
   name: 'missions',
-
   initialState,
-
   reducers: {
-
+    joinMission: (state, action) => {
+      const missionId = action.payload;
+      state.missions = state.missions.map((mission) => {
+        if (mission.mission_id === missionId) {
+          return { ...mission, joined: true };
+        }
+        return mission;
+      });
+    },
+    leaveMission: (state, action) => {
+      const missionId = action.payload;
+      state.missions = state.missions.map((mission) => {
+        if (mission.mission_id === missionId) {
+          return { ...mission, joined: false };
+        }
+        return mission;
+      });
+    },
   },
-
   extraReducers: (builder) => {
     builder
-
       .addCase(fetchMissions.pending, (state) => {
         state.status = 'loading';
       })
-
       .addCase(fetchMissions.fulfilled, (state, action) => {
         state.status = 'succeeded';
-
-        state.rockets = action.payload;
+        state.missions = action.payload;
       })
-
       .addCase(fetchMissions.rejected, (state, action) => {
         state.status = 'failed';
-
         state.error = action.error.message;
       });
   },
-
 });
+
+export const { joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
In this pull request, I implemented functionalities that include:

- Mission Joining: When the user clicks the "Join Mission" button, an action is dispatched to update the store, setting the 'joined' key to true for the selected mission.

- Mission Leaving: Similarly, when the user clicks the "Leave Mission" button, an action is dispatched to update the store, this time setting the 'joined' key to false for the selected mission.

- Conditional Rendering: As part of these enhancements, the rendering of components has been updated. An "Active Member" badge and a "Leave Mission" button are now rendered for joined missions, providing a clearer representation of the user's active participation. A "NOT A MEMBER" badge and a "Join Mission" button are displayed for non-joined missions, guiding users to join and be part of these missions.